### PR TITLE
bugfix: avoid crash after a long time spent on dashboard

### DIFF
--- a/luci-app-overthebox/luasrc/view/overthebox/index.htm
+++ b/luci-app-overthebox/luasrc/view/overthebox/index.htm
@@ -38,6 +38,10 @@
 	$(document).ready(function(){
 		$('[data-toggle="popover"]').popover();
 	});
+	// Avoid browser crash after a long time spent on this page
+	window.setInterval(function(){
+		document.location.reload(true);
+	}, 1000 * 60 * 60);
 </script>
 
 <script type="text/javascript">//<![CDATA[


### PR DESCRIPTION
After a long time spent on the dashboard, the browser crash