### PR TITLE
fix for satellite (con't)

### DIFF
--- a/mwan3otb/files/usr/sbin/track.lua
+++ b/mwan3otb/files/usr/sbin/track.lua
@@ -84,9 +84,9 @@ function ping ( host, interface, timeout)
 		  else
 		    if err == 11 then
 		      cnt=cnt-1
-		      debug("JLB ping:"..cnt.." "..sa)
+		      debug("ping:"..cnt.." "..sa)
 		    else
-		      debug("JLB ping:"..sa)
+		      debug("ping:"..sa)
 		      break
 		    end
 		  end
@@ -151,9 +151,9 @@ function dns_request( host, interface, timeout, domain)
 	  else
 	    if err == 11 then
 	      cnt=cnt-1
-	      debug("JLB nslookup:"..cnt.." "..sa)
+	      debug("nslookup:"..cnt.." "..sa)
             else
-	      debug("JLB nslookup:"..sa)
+	      debug("nslookup:"..sa)
 	      break;
 	    end
 	  end

--- a/mwan3otb/files/usr/sbin/track.lua
+++ b/mwan3otb/files/usr/sbin/track.lua
@@ -75,7 +75,22 @@ function ping ( host, interface, timeout)
 		if not ok then return ok, err end
 
 		-- Read reply
-		local data, sa = p.recvfrom(fd, 1024)
+		local cnt=3
+		local data,sa,err
+		while cnt > 0  do
+		  data, sa, err = p.recvfrom(fd, 1024)
+		  if data then
+		    break
+		  else
+		    if err == 11 then
+		      cnt=cnt-1
+		      debug("JLB ping:"..cnt.." "..sa)
+		    else
+		      debug("JLB ping:"..sa)
+		      break
+		    end
+		  end
+		end
 		local t2 = p.clock_gettime(p.CLOCK_REALTIME) 
 		if fd then p.close(fd) end
 		if data then
@@ -85,6 +100,7 @@ function ping ( host, interface, timeout)
 			elseif r==11  then return false, "timeout error"
 			else
 				-- hex_dump(data)
+
                                 return false, "other error : "..r
 			end
 		else
@@ -126,7 +142,23 @@ function dns_request( host, interface, timeout, domain)
 	local ok, err = p.sendto (fd, data, { family = p.AF_INET, addr = host, port = 53 })
 	if not ok then return ok, err end
 
-	local data, sa = p.recvfrom(fd, 1024)
+	local cnt=3
+	local data,sa,err
+	while cnt > 0  do
+	  data, sa, err = p.recvfrom(fd, 1024)
+	  if data then
+	    break
+	  else
+	    if err == 11 then
+	      cnt=cnt-1
+	      debug("JLB nslookup:"..cnt.." "..sa)
+            else
+	      debug("JLB nslookup:"..sa)
+	      break;
+	    end
+	  end
+	end
+
 	local t2 = p.clock_gettime(p.CLOCK_REALTIME)
 	if fd then p.close(fd) end
 	if data then

--- a/mwan3otb/files/usr/sbin/track.lua
+++ b/mwan3otb/files/usr/sbin/track.lua
@@ -80,7 +80,12 @@ function ping ( host, interface, timeout)
 		while cnt > 0  do
 		  data, sa, err = p.recvfrom(fd, 1024)
 		  if data then
-		    break
+                    local r = string.byte(data, 21, 22) -- byte of the first char
+                    if r == 8 then
+                      debug("ping: skip ECHO-request")
+                    else
+                      break
+                    end
 		  else
 		    if err == 11 then
 		      cnt=cnt-1


### PR DESCRIPTION
ping and nslookup recvfrom function can exit on signal causing EAGAIN (11) error
In this case a new recvfrom call is required to resume.
As track on ICMP is now used by TUN and XTUN this fix is required.
add test for incoming ECHO request
