### PR TITLE
Return an error when opkg update fails during upgrade.

### DIFF
--- a/overthebox/files/usr/bin/overtheboxd
+++ b/overthebox/files/usr/bin/overtheboxd
@@ -73,10 +73,10 @@ while run do
 					overthebox.update_release_channel()
 				end
 			end
-			actionreturn, msg = overthebox.opkg_update()
-
-			actionreturn, tmsg = overthebox.upgrade()
-			msg = msg .. "\n" .. tmsg
+			return_update, msg_update = overthebox.opkg_update()
+			return_upgrade, msg_upgrade = overthebox.upgrade()
+			actionreturn = return_update and return_upgrade
+			msg = msg_update .. "\n" .. msg_upgrade
 		elseif ret.action == "updateReleaseChannel" then
 			actionreturn, msg = overthebox.update_release_channel()
 		elseif ret.action == "sysupgrade" then


### PR DESCRIPTION
When upgrade action was launched, if opkg update failed, the action was returned as succeeded even though a part of it failed.