### PR TITLE
Update glorytun-udp to 0.0.67-mud

### DIFF
--- a/glorytun-udp/Makefile
+++ b/glorytun-udp/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glorytun-udp
-PKG_VERSION:=0.0.65-mud
+PKG_VERSION:=0.0.67-mud
 PKG_RELEASE:=3
 PKG_SOURCE:=glorytun-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/angt/glorytun/releases/download/v$(PKG_VERSION)

--- a/glorytun-udp/files/glorytun.sh
+++ b/glorytun-udp/files/glorytun.sh
@@ -53,7 +53,6 @@ GTPID=$!
 # This function sets up the tun interface
 initialized() {
     ip addr add ${GLORYTUN_IP_LOCAL} peer ${GLORYTUN_IP_PEER} dev ${GLORYTUN_DEV}
-    ip link set ${GLORYTUN_DEV} mtu ${GLORYTUN_MTU}
     ip link set ${GLORYTUN_DEV} txqueuelen ${GLORYTUN_TXQLEN}
 
     multipath ${GLORYTUN_DEV} off


### PR DESCRIPTION
This commit adds MTU negotiation and fixes the 'trap invalid opcode' issue.