### PR TITLE
Do not throttle tcp_timeout_established down

### DIFF
--- a/overthebox/files/etc/sysctl.d/shadowsocks.conf
+++ b/overthebox/files/etc/sysctl.d/shadowsocks.conf
@@ -44,4 +44,3 @@ net.ipv4.tcp_mtu_probing = 0
 
 # Default conntrack is too small
 net.netfilter.nf_conntrack_max=131072
-net.netfilter.nf_conntrack_tcp_timeout_established=120


### PR DESCRIPTION
The 120s tcp_timeout_established of commit b0f09f7 has way too many
side-effects.

Signed-off-by: Martin Wetterwald <martin.wetterwald@corp.ovh.com>