### PR TITLE
Put an end to the dnsmasq/dnsmasq-full battle

### DIFF
--- a/dnsmasq/Makefile
+++ b/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.76
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -82,9 +82,6 @@ if [ -z $${IPKG_INSTROOT} ] ; then
 	[ -x /etc/init.d/qos ] && /etc/init.d/qos enable ;
 	[ -x /etc/init.d/dscp ] && /etc/init.d/dscp enable ;
 
-	[ -x /etc/init.d/dnsmasq ] && /etc/init.d/dnsmasq enable ;
-	[ -x /etc/init.d/dnsmasq ] && /etc/init.d/dnsmasq restart ;
-
 	# force clear luci cache
 	rm -fr /tmp/luci-indexcache /tmp/luci-modulecache
 


### PR DESCRIPTION
dnsmasq-full is a "VARIANT" (using openWRT Makefile terminology) of
dnsmasq. This means they share most of their files, because dnsmasq-full
just enables more features than dnsmasq does.

dnsmasq and dnsmasq-full were both installed. #a7a4abb changed a
dependency in package overthebox from "dnsmasq" to "dnsmasq-full". This
is because we only need dnsmasq-full. But by doing so, dnsmasq was
automatically removed. This happens because dnsmasq was auto-installed
(install triggered by a dependency satisfaction) and no package depend
on it any more.  If dnsmasq had been installed after dnsmasq-full, it
was considered to be the one which triggered the files installation (see
file /usr/lib/opkg/info/dnsmasq.list). And in that case, when dnsmasq is
auto-removed, the files vanish together with it, letting an unusable,
stopped and disabled dnsmasq-full ghost on the system.

This patch ensures that dnsmasq is uninstalled and that dnsmasq-full is
declared being responsible of the installation of its files
(/usr/lib/opkg/info/dnsmasq-full.list).

Some interesting links to understand when "enable" and "disable" happen:
https://github.com/ovh/overthebox-openwrt/blob/3a745d9/package/Makefile#L117
https://github.com/ovh/overthebox-openwrt/blob/3a745d9/package/base-files/files/lib/functions.sh#L225
https://github.com/ovh/overthebox-openwrt/blob/3a745d9/package/base-files/files/lib/functions.sh#L171
https://github.com/ovh/overthebox-openwrt/blob/3a745d9/package/base-files/files/etc/rc.common#L43

Signed-off-by: Martin Wetterwald <martin.wetterwald@corp.ovh.com>