### PR TITLE
Prevent luci apps from being upgraded all the time

### DIFF
--- a/luci-app-overthebox/Makefile
+++ b/luci-app-overthebox/Makefile
@@ -9,6 +9,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for the OverTheBox project
 LUCI_DEPENDS:=+luci-app-mwan3otb +bandwidth
 
+PKG_VERSION:=v1.0
+PKG_RELEASE:=1
+
 include ../luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-base/Makefile
+++ b/luci-base/Makefile
@@ -14,6 +14,9 @@ LUCI_BASENAME:=base
 LUCI_TITLE:=LuCI core libraries
 LUCI_DEPENDS:=+lua +libuci-lua +luci-lib-nixio +luci-lib-ip +rpcd +libubus-lua
 
+PKG_VERSION:=v1.0
+PKG_RELEASE:=1
+
 PKG_SOURCE:=LuaSrcDiet-0.12.1.tar.bz2
 PKG_SOURCE_URL:=https://luasrcdiet.googlecode.com/files
 PKG_MD5SUM:=8a0812701e29b6715e4d76f2f118264a

--- a/luci-mod-admin-full/Makefile
+++ b/luci-mod-admin-full/Makefile
@@ -11,6 +11,9 @@ LUCI_DEPENDS:=+luci-base +libubus-lua
 
 PKG_BUILD_DEPENDS:=iwinfo
 
+PKG_VERSION:=v1.0
+PKG_RELEASE:=1
+
 include ../luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
luci-app-overthebox, luci-base and luci-mod-admin-full were upgraded at
each OTB upgrade, even if those packets were already up-to-date. This is
because by default, if PKG_VERSION is not set, luci generates a
PKG_VERSION using the git commit sha1 and the date. This caused the
version number to change all the time, triggering useless upgrades each
time.

https://github.com/ovh/overthebox-feeds/blob/master/luci/luci.mk#L61

Signed-off-by: Martin Wetterwald <martin.wetterwald@corp.ovh.com>