### PR TITLE
Fix missing uci commit in uhttpd defaults

### DIFF
--- a/overthebox/defaults/uhttpd.defaults
+++ b/overthebox/defaults/uhttpd.defaults
@@ -3,3 +3,4 @@
 # Do not redirect http to https, allow both
 # overthebox.ovh will redirect to http for easier configuration
 uci set uhttpd.main.redirect_https='0'
+uci commit uhttpd


### PR DESCRIPTION
If we don't commit the change it will appear as an unsaved change
It fixes the bug introduced by #221

Signed-off-by: Lucas BEE <lucas.bee@corp.ovh.com>