### PR TITLE
Set default dnsmasq values about IPv6

### DIFF
--- a/overthebox/defaults/dnsmasq.defaults
+++ b/overthebox/defaults/dnsmasq.defaults
@@ -1,10 +1,23 @@
 #!/bin/sh
 
-uci delete dhcp.@dnsmasq[0].nonegcache
+# Disable caching of negative "no such domain" responses
+uci -q delete dhcp.@dnsmasq[0].nonegcache
+# Ask all servers for a response, take the fastest successful one
 uci set dhcp.@dnsmasq[0].all_servers='1'
+# Set the size of the cache
 uci set dhcp.@dnsmasq[0].cachesize='8192'
+# Tell dnsmasq that there might be other DHCP servers in the network
 uci set dhcp.@dnsmasq[0].authoritative='0'
-uci commit dhcp
+
+# Custom option to filter AAAA responses as IPv6 is not yet enabled
+uci set dhcp.@dnsmasq[0].filter_aaaa='1'
+# Disable Router Advertisements
+uci -q delete dhcp.lan.ra
+uci -q delete dhcp.lan.ra_default
+uci -q delete dhcp.lan.ra_management
+uci -q delete dhcp.lan.ra_preference
+# Disable DHCPv6 server
+uci -q delete dhcp.lan.dhcpv6
 
 if grep overthebox.ovh /etc/dnsmasq.conf 1>/dev/null 2>/dev/null; then
 	sed -i.bak '/overthebox.ovh/d' /etc/dnsmasq.conf
@@ -17,8 +30,9 @@ if ! uci show dhcp | grep 'overthebox' 1>/dev/null 2>/dev/null; then
 	uci add dhcp cname
 	uci set dhcp.@cname[-1].cname='overthebox.ovh'
 	uci set dhcp.@cname[-1].target='lan'
-	uci commit dhcp
 fi
+
+uci commit dhcp
 
 exit 0
 


### PR DESCRIPTION
Disable all IPv6 values by default.
These values are in conflict with the fact that IPv6 is not yet
implemented in OTB and can create navigation issues
These values were deleted in 1b917427ab by mistake

Signed-off-by: Lucas BEE <lucas.bee@corp.ovh.com>