### PR TITLE
Fix mwan3 reload behaviour

### DIFF
--- a/overthebox/files/usr/lib/lua/overthebox.lua
+++ b/overthebox/files/usr/lib/lua/overthebox.lua
@@ -1743,13 +1743,10 @@ function update_confmwan()
 	uci:set("mwan3", "netconfchecksum", newmd5)
 	uci:save("mwan3")
 	uci:commit("mwan3")
-	-- Saving net conf md5 and restarting services
-	if os.execute("mwan3 status 1>/dev/null 2>/dev/null") == 0 then
-		os.execute("/etc/init.d/network reload")
-		os.execute("/etc/init.d/firewall reload")
-		os.execute("nohup /usr/sbin/mwan3 restart &")
-	end
+	-- Release mwan3 lock
 	l:close()
+	-- Ask uci to reload mwan3 service if needed
+	os.execute("/sbin/reload_config mwan3")
 	return result, interfaces
 end
 


### PR DESCRIPTION
- remove restart of not dependant services as network and firewall (which is reloaded by mwan3 himself)
- use reload_config helper to restart mwan3 only when the mwan3 config has changed, should correct a possible race condition reload.