### PR TITLE
Fix mwan3 bad nil check

### DIFF
--- a/mwan3otb/files/usr/sbin/track.lua
+++ b/mwan3otb/files/usr/sbin/track.lua
@@ -922,7 +922,7 @@ while true do
 
 					score = 0
 				else
-					if dlspeed ~= nil or upspeed ~= nil then
+					if dlspeed ~= nil and upspeed ~= nil then
 						log(string.format("Interface %s (%s) lost his tracker but we still have some traffic (up %s kbit/s, dn %s kbit/s)", opts["i"], opts["d"], dlspeed, upspeed))
 						shaper.losttimestamp = os.time()
 					else


### PR DESCRIPTION
Fix the error : 

`daemon.err mwan3track[2194]: lua: /usr/sbin/mwan3track:1042: bad argument #4 to 'format' (string expected, got nil)`