### PR TITLE
Bring back teardown PTP

### DIFF
--- a/netifd/files/lib/netifd/proto/ptp.sh
+++ b/netifd/files/lib/netifd/proto/ptp.sh
@@ -22,4 +22,9 @@ proto_ptp_setup() {
 	proto_send_update "$interface"
 }
 
+proto_ptp_teardown() {
+  # No actions to do
+  :
+}
+
 add_protocol ptp


### PR DESCRIPTION
It was awening with errors saying :
tun0 (8749): ./ptp.sh: eval: line 1: proto_ptp_teardown: not found