### PR TITLE
ss-redir-init: Be more tolerant in uci syntax

### DIFF
--- a/shadowsocks-libev/Makefile
+++ b/shadowsocks-libev/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=2.5.0-1-ovh-3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ovh/overthebox-shadowsocks-libev/archive
 

--- a/shadowsocks-libev/files/shadowsocks.init
+++ b/shadowsocks-libev/files/shadowsocks.init
@@ -385,13 +385,19 @@ _populate_ipt_socks_hook() {
 # $1 is a ref to the current zone section being processed
 _update_socks_hook_one_zone() {
     # Let's fetch the current zone name
-    local zone
+    local zone zone_members
     config_get zone $1 name
 
     # Only traffic coming from a lan zone's interface will be routed to shadowsocks
     if [ "$zone" = "lan" ]; then
+        # We don't use config_list_foreach so that we are compatible with lists AND single string with spaces
+        config_get zone_members $1 network
+
         # Call this callback for each interface belonging to the lan zone
-        config_list_foreach $1 network _update_socks_hook_one_if
+        # Don't put double quotes around $zone_members or the loop will iterate only once
+        for member in $zone_members; do
+            _update_socks_hook_one_if $member
+        done
     fi
 }
 


### PR DESCRIPTION
In the ss-redir init script, we fill the iptables chain "socks_hook"
with one rule per interface belonging to the zone "lan".
Sometimes, the syntax used in the uci configuration is:
```
list network 'lan1'
list network 'lan2'
```
whereas sometimes, it's:
```option network 'lan1 lan2'```

We only supported the former syntax. This patch add support for the
latter syntax to me more robust.