### PR TITLE
Bump versions

### DIFF
--- a/bandwidth/Makefile
+++ b/bandwidth/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bandwidth
-PKG_VERSION:=0.6.2
+PKG_VERSION:=0.6.3
 PKG_RELEASE=1
 PKG_MAINTAINER:=Martin Wetterwald <martin.wetterwald@corp.ovh.com>
 

--- a/dnsmasq/Makefile
+++ b/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.76
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/glorytun-udp/Makefile
+++ b/glorytun-udp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glorytun-udp
 PKG_VERSION:=0.0.89-mud
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_SOURCE:=glorytun-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/angt/glorytun/releases/download/v$(PKG_VERSION)
 PKG_BUILD_DIR:=glorytun-$(PKG_VERSION)

--- a/glorytun/Makefile
+++ b/glorytun/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glorytun
 PKG_VERSION:=0.0.34
-PKG_RELEASE=5
+PKG_RELEASE=6
 PKG_SOURCE:=glorytun-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/angt/glorytun/releases/download/v$(PKG_VERSION)
 PKG_MD5SUM:=94b26771867d45e00a766d6aa73fe942

--- a/luci-app-overthebox/Makefile
+++ b/luci-app-overthebox/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for the OverTheBox project
 LUCI_DEPENDS:=+luci-app-mwan3otb +bandwidth
 
-PKG_VERSION:=v1.0
-PKG_RELEASE:=3
+PKG_VERSION:=v1.1
+PKG_RELEASE:=1
 
 include ../luci/luci.mk
 

--- a/luci-base/Makefile
+++ b/luci-base/Makefile
@@ -14,7 +14,7 @@ LUCI_BASENAME:=base
 LUCI_TITLE:=LuCI core libraries
 LUCI_DEPENDS:=+lua +libuci-lua +luci-lib-nixio +luci-lib-ip +rpcd +libubus-lua
 
-PKG_VERSION:=v1.0
+PKG_VERSION:=v1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=LuaSrcDiet-0.12.1.tar.bz2

--- a/luci-theme-ovh/Makefile
+++ b/luci-theme-ovh/Makefile
@@ -7,8 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-theme-ovh
-PKG_VERSION:=v0.1
-PKG_RELEASE:=3
+PKG_VERSION:=v0.2
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Simon Lelievre <simon.lelievre@corp.ovh.com>
 PKG_LICENSE:=GPLv2
 

--- a/mptcp/Makefile
+++ b/mptcp/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) 2014-2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v3 or later.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mptcp
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_MAINTAINER:=Mario Krueger <openwrt@xedp3x.de>
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)

--- a/mwan3otb-luci/Makefile
+++ b/mwan3otb-luci/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-mwan3otb
 PKG_VERSION:=1.5
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_MAINTAINER:=Aedan Renner <chipdankly@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/mwan3otb/Makefile
+++ b/mwan3otb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3otb
 PKG_VERSION:=1.7
-PKG_RELEASE:=33
+PKG_RELEASE:=34
 PKG_MAINTAINER:=Jeroen Louwes <jeroen.louwes@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/netifd/Makefile
+++ b/netifd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
 PKG_VERSION:=2015-08-25
-PKG_RELEASE=61
+PKG_RELEASE=62
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=http://git.openwrt.org/project/netifd.git

--- a/shadowsocks-libev/Makefile
+++ b/shadowsocks-libev/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=2.5.0-1-ovh-3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ovh/overthebox-shadowsocks-libev/archive
 


### PR DESCRIPTION
Package version bumped:

* bandwidth/Makefile
* dnsmasq/Makefile
* glorytun-udp/Makefile
* glorytun/Makefile
* luci-app-overthebox/Makefile
* luci-base/Makefile
* luci-theme-ovh/Makefile
* mptcp/Makefile
* mwan3otb-luci/Makefile
* mwan3otb/Makefile
* netifd/Makefile
* shadowsocks-libev/Makefile

Signed-off-by: Grégoire Delattre <gregoire.delattre@corp.ovh.com>