### PR TITLE
swconfig-otb: Add dependency python-setuptools

### DIFF
--- a/swconfig-otb/Makefile
+++ b/swconfig-otb/Makefile
@@ -14,7 +14,7 @@ define Package/python-swconfig-otb
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Tools to manage OVH OverTheBox switches
-  DEPENDS:=+python-light +python-logging +python-pyserial
+  DEPENDS:=+python-light +python-setuptools +python-logging +python-pyserial
 endef
 
 define Package/python-swconfig-otb/description


### PR DESCRIPTION
Signed-off-by: Adrien Gallouët <adrien.gallouet@corp.ovh.com>