### PR TITLE
overthebox: Move OTB build key in uci-defaults

### DIFF
--- a/overthebox/files/etc/opkg/keys/6bc78405bb9b7cc3
+++ b/overthebox/files/etc/opkg/keys/6bc78405bb9b7cc3
@@ -1,2 +1,0 @@
-untrusted comment: OTB build key
-RWRrx4QFu5t8wxTWDz+ErjM4vJhhhPzPvEJqaheYtgQXZuFSa+ndn91U

--- a/overthebox/files/etc/uci-defaults/otb-key.defaults
+++ b/overthebox/files/etc/uci-defaults/otb-key.defaults
@@ -1,0 +1,11 @@
+#!/bin/sh
+# vim: set noexpandtab tabstop=4 shiftwidth=4 softtabstop=4 :
+
+OTB_KEY_FILE=/etc/opkg/keys/6bc78405bb9b7cc3
+
+[ -d "$OTB_KEY_FILE" ] && exit
+
+cat > "$OTB_KEY_FILE" <<EOF
+untrusted comment: OTB build key
+RWRrx4QFu5t8wxTWDz+ErjM4vJhhhPzPvEJqaheYtgQXZuFSa+ndn91U
+EOF


### PR DESCRIPTION
Removing the package overthebox should not remove the key.

Signed-off-by: Adrien Gallouët <adrien.gallouet@corp.ovh.com>