### PR TITLE
overthebox: Remove bash as it's now useless

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/package.mk
 MY_DEPENDS := graph dnsmasq-full glorytun glorytun-udp luci-app-overthebox \
 	mptcp shadowsocks-libev luaposix luasec luasocket file \
 	getopt dmidecode tc iperf3 mtr bind-dig owipcalc ethtool \
-	bash rng-tools ss strace tcpdump-mini conntrack conntrackd \
+	rng-tools ss strace tcpdump-mini conntrack conntrackd \
 	luci luci-lib-json luci-theme-bootstrap ca-certificates \
 	libustream-mbedtls luci-lib-px5g px5g kmod-ipt-raw ip-full \
 	iptables-mod-trace curl ca-bundle jq


### PR DESCRIPTION
Signed-off-by: Adrien Gallouët <adrien.gallouet@corp.ovh.com>