### PR TITLE
otb-remote: Fix public key location

### DIFF
--- a/otb-remote/init
+++ b/otb-remote/init
@@ -33,7 +33,12 @@ start_instance() {
 
 	mkdir -p -m 0700 "${dir}"
 	echo "${host} ${server_public_key% *}" > "${dir}/known_hosts"
-	echo "${remote_public_key}" > "${dir}/authorized_keys"
+
+	# Add the remote user pubkey in the authorized_keys of root
+	if ! grep -sq "$1" /etc/dropbear/authorized_keys; then
+		echo "${remote_public_key} ${1}" >> /etc/dropbear/authorized_keys
+	fi
+
 	chmod 0600 "${dir}/known_hosts" "${dir}/authorized_keys"
 
 	procd_open_instance

--- a/otb-remote/otb-action-remoteAccessDisconnect
+++ b/otb-remote/otb-action-remoteAccessDisconnect
@@ -9,6 +9,8 @@ set -e
 remote_access_id="$(otb_json_get "$1" 'arguments.remote_access_id')"
 uci_id=$(echo "$remote_access_id" | tr - _)
 
+sed -i "/$uci_id/d" /etc/dropbear/authorized_keys
+
 luci_user=$(uci -q get otb-remote."${uci_id}".luci_user) || true
 [ -n "$luci_user" ] && deluser "$luci_user"
 


### PR DESCRIPTION
remote user public keys are now all in the same and unique valid file
for the root user : /etc/dropbear/authorized_keys