### PR TITLE
luci-app-overthebox: Fix typo

### DIFF
--- a/luci-app-overthebox/luasrc/controller/admin/overthebox.lua
+++ b/luci-app-overthebox/luasrc/controller/admin/overthebox.lua
@@ -199,7 +199,7 @@ function interfaces_status()
       multipath = section['multipath'],
       status = net:_ubus("data").connectivity,
       wanip = net:_ubus("data").public_ip,
-      whois = asn and as.as_description or "unknown",
+      whois = asn and asn.as_description or "unknown",
       qos = section['trafficcontrol'],
       download = section['download'],
       upload = section['upload']


### PR DESCRIPTION
Typo introduced here 06ba2d6d6f18aac21c6fdc3c02d59c8e65a1b7ce

https://w000t.me/066492a738

Signed-off-by: Lucas BEE <lucas.bee@corp.ovh.com>