### PR TITLE
glorytun-udp: Only start when everybody is ready

### DIFF
--- a/glorytun-udp/Makefile
+++ b/glorytun-udp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glorytun-udp
 PKG_VERSION:=0.0.89-mud
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 PKG_SOURCE:=glorytun-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/angt/glorytun/releases/download/v$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/glorytun-$(PKG_VERSION)

--- a/glorytun-udp/start
+++ b/glorytun-udp/start
@@ -1,14 +1,23 @@
 #!/bin/sh
+# vim: set noexpandtab tabstop=4 shiftwidth=4 softtabstop=4 :
 
 . /lib/functions.sh
 . /lib/functions/network.sh
 
 BIND_ARGS=
 
+_err() {
+	logger -p daemon.err -t "glorytun-udp" "$@"
+}
+
 _setup_bind_args() {
 	multipath=
 	config_get multipath "$1" multipath
 	if [ "$multipath" = "on"  ] || [ "$multipath" = "master" ]; then
+		if ! network_is_up "$1"; then
+			_err "$1 is not yet up, aborting"
+			exit 1
+		fi
 		ipaddr=
 		network_get_ipaddr ipaddr "$1"
 		[ -n "$ipaddr" ] && BIND_ARGS="${BIND_ARGS}${ipaddr},"


### PR DESCRIPTION
When a new interface is added, glorytun is restarted, but the restart
can happen before an IP is set on the interface, and event before the
interface is up
If the interface is not up, let glorytun restart itself 30 seconds
later

Fixes #645 

Signed-off-by: Lucas BEE <lucas.bee@corp.ovh.com>