### PR TITLE
otb-tracker: Remove timeout from post-tracking

### DIFF
--- a/otb-tracker/bin
+++ b/otb-tracker/bin
@@ -1,7 +1,9 @@
 #!/bin/sh
 # vim: set noexpandtab tabstop=4 shiftwidth=4 softtabstop=4 :
 
+# shellcheck disable=SC1091
 . /lib/functions.sh
+# shellcheck disable=SC1091
 . /lib/functions/network.sh
 
 [ -n "$1" ] && [ -n "$2" ] || exit
@@ -109,7 +111,7 @@ while true; do
 	for tracker_bin in /usr/share/otb/post-tracking.d/*; do
 		[ -x "$tracker_bin" ] || continue
 		#shellcheck disable=SC2091
-		timeout -t "$OTB_TRACKER_POST_TRACKING_TIMEOUT" "$tracker_bin" &
+		"$tracker_bin" &
 	done
 	sleep "$OTB_TRACKER_INTERVAL"
 done

--- a/otb-tracker/init
+++ b/otb-tracker/init
@@ -13,7 +13,6 @@ _validate_section() {
 		'timeout:uinteger:3' \
 		'tries:uinteger:3' \
 		'interval:uinteger:2' \
-		'post_tracking_timeout:uinteger:2' \
 		'options:string:tracker.overthebox.ovh'
 }
 
@@ -47,7 +46,6 @@ _launch_tracker() {
 	procd_append_param env OTB_TRACKER_TIMEOUT="$timeout"
 	procd_append_param env OTB_TRACKER_TRIES="$tries"
 	procd_append_param env OTB_TRACKER_INTERVAL="$interval"
-	procd_append_param env OTB_TRACKER_POST_TRACKING_TIMEOUT="$post_tracking_timeout"
 	procd_set_param respawn 0 10 0
 	procd_set_param stderr 1
 	procd_close_instance


### PR DESCRIPTION
Current post_tracking scripts have been tested and concurrency is not a problem.
Make sure next post_tracking scripts can be executed concurrently before integrating them.

Be aware that termination order can not be anticipated.

Signed-off-by: Kevin Lanvin <kevin.lanvin@corp.ovh.com>