### PR TITLE
overthebox: gunzip and -p are now useless for sysupgrade

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.26
+PKG_VERSION:=0.27
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/bin/otb-action-sysupgrade
+++ b/overthebox/files/bin/otb-action-sysupgrade
@@ -25,11 +25,8 @@ curl -sS --connect-timeout 5 "$url.sig" -o img.gz.sig
 
 usign -V -m img.gz -P /etc/opkg/keys
 
-otb_info "Decompressing image..."
-gunzip -f img.gz
-
 otb_info "Testing sysupgrade..."
-sysupgrade -p -T img
+sysupgrade -T img.gz
 
 otb_info "Performing sysupgrade..."
-sysupgrade -p img
+sysupgrade img.gz


### PR DESCRIPTION
Signed-off-by: Adrien Gallouët <adrien.gallouet@corp.ovh.com>