### PR TITLE
otb-autoroute: Fix quotes in ip rules

### DIFF
--- a/otb-autoroute/Makefile
+++ b/otb-autoroute/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=otb-autoroute
-PKG_VERSION:=1.5
+PKG_VERSION:=1.6
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/otb-autoroute/bin
+++ b/otb-autoroute/bin
@@ -16,7 +16,7 @@ _setup_high_priority_rule() {
 	# pref 30000 to be between the interfaces rules (20000, value set by
 	# netifd) and the main routing table (32766, default value)
 	_log "$1 rule matching $mark using table $2 and pref 30000"
-	ip rule "$1" fwmark "$mark" table "$2 pref 30000"
+	ip rule "$1" fwmark "$mark" table "$2" pref 30000
 }
 
 config_load shadowsocks


### PR DESCRIPTION
Quotes were creating errors : 
```user.notice post-tracking-otb-autoroute: add rule matching 0x7874756e using table 101 and pref 30000
daemon.err otb-tracker[7889]: Error: argument "101 pref 30000" is wrong: invalid table ID
daemon.err otb-tracker[7889]:
```

Signed-off-by: Lucas BEE <lucas.bee@corp.ovh.com>