### PR TITLE
overthebox: Fix infinite wan discovery

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.37
+PKG_VERSION:=0.38
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/etc/udhcpc.user
+++ b/overthebox/files/etc/udhcpc.user
@@ -68,7 +68,7 @@ manage_if0() {
 		set network.if${_id}.ipaddr=$ip
 		set network.if${_id}.netmask=$subnet
 		set network.if${_id}.multipath=on
-		set network.if${_id}.gateway=$router
+		set network.if${_id}.gateway="$router"
 		set network.if${_id}.dns=$dns
 		set network.${INTERFACE}_dev.macaddr=auto.if$_id
 		commit network


### PR DESCRIPTION
Occured when a dhcp server was giving multiple gateways
Fixes #754

Signed-off-by: Lucas BEE <lucas.bee@corp.ovh.com>