### PR TITLE
shadowsocks: Reload if the firewall config change

### DIFF
--- a/shadowsocks-libev/Makefile
+++ b/shadowsocks-libev/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/shadowsocks-libev/files/shadowsocks.init
+++ b/shadowsocks-libev/files/shadowsocks.init
@@ -52,7 +52,7 @@ LOCALNETS="
 
 # When following config files change and reload_config is called, we trigger a reload here
 service_triggers() {
-	procd_add_reload_trigger "shadowsocks" "network"
+	procd_add_reload_trigger "shadowsocks" "network" "firewall"
 }
 
 _running() {


### PR DESCRIPTION
This allows shadowsocks to always be the last entry in the nat table of
the PREROUTING chain.

Fixes #786