### PR TITLE
overthebox: Set the lan rule in the config

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.40
+PKG_VERSION:=0.41
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/etc/hotplug.d/net/10-otb-lan
+++ b/overthebox/files/etc/hotplug.d/net/10-otb-lan
@@ -1,4 +1,0 @@
-#!/bin/sh
-# vim: set noexpandtab tabstop=4 shiftwidth=4 softtabstop=4 :
-
-ip rule | grep -q "100:" || ip rule add from all lookup lan pref 100

--- a/overthebox/files/etc/uci-defaults/1910-otb-network
+++ b/overthebox/files/etc/uci-defaults/1910-otb-network
@@ -22,6 +22,14 @@ reorder network.lan=2
 set network.globals.multipath=enable
 EOF
 
+# Set the ip rule for the lan with a pref of 100
+uci -q show network.lan_rule >/dev/null || \
+	uci -q batch <<-EOF
+	set network.lan_rule=rule
+	set network.lan_rule.lookup=lan
+	set network.lan_rule.priority=100
+	EOF
+
 if [ "$(uci -q get network.vpn0.proto)" = "none" ]; then
 	uci -q delete network.vpn0
 fi


### PR DESCRIPTION
Clean the changes introduced in d62b39d. Use the network configuration
file to setup the rule instead of a hotplug script.