### PR TITLE
shadowsocks-libev: Add output rules

### DIFF
--- a/shadowsocks-libev/Makefile
+++ b/shadowsocks-libev/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/shadowsocks-libev/files/shadowsocks.init
+++ b/shadowsocks-libev/files/shadowsocks.init
@@ -422,6 +422,12 @@ _update_ipt_monitoring_ip_rule() {
 	# Note that any running overthebox_test_download_proof will be pwned here :p This is fine.
 	$IPT -F socks_emitted_by_myself
 
+	# downloads.overthebox.net and provisionning.overthebox.net should go through the tunnel with a cs2 priority
+	$IPT -A socks_emitted_by_myself -d "downloads.overthebox.net" -p tcp \
+		-m comment --comment "downloads.overthebox.net (CS2)" -j REDIRECT --to-ports $((lport + 2))
+	$IPT -A socks_emitted_by_myself -d "provisionning.overthebox.net" -p tcp --dport 4443 \
+		-m comment --comment "provisionning.overthebox.net (CS2)" -j REDIRECT --to-ports $((lport + 2))
+
 	# Only add the rule if monitoring_ip is set and the tracker binary is there
 	if [ -n "$monitoring_ip" -a -x "$TRACKER" ]; then
 		# Add the special rule so that when we send a packet to the monitoring_ip, it flows through ss-redir


### PR DESCRIPTION
TCP traffic for internal needs should go through shadowsocks for the
following URLs:
* downloads.overthebox.net
* provisionning.overthebox.net