### PR TITLE
overthebox: Setup MSS clamping in lan

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.45
+PKG_VERSION:=0.46
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/etc/uci-defaults/1900-firewall
+++ b/overthebox/files/etc/uci-defaults/1900-firewall
@@ -56,6 +56,7 @@ config_foreach _setup zone
 config_foreach _delete_mptcp_forwarding forwarding
 
 uci -q batch <<-EOF
+set firewall.lan.mtu_fix=1
 del_list firewall.lan.network=if0
 del_list firewall.wan.network=if0
 add_list firewall.wan.network=if0


### PR DESCRIPTION
Some users experience hangs while using the port forwarding from the
public IP to a specific web server in the lan. If the web server
response is to big, the OTB will send a ICMP packet to tell it to
defragment the packet. If the web server does not handle this
fragmentation the end user will never receive the data.
Enabling the MSS clamping on the lan will allow both parties to
negotiate the correct MSS and to communicate without fragmentation.