### PR TITLE
overthebox: Better speedtest

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.48
+PKG_VERSION:=0.49
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/bin/otb-action-speedtest
+++ b/overthebox/files/bin/otb-action-speedtest
@@ -103,6 +103,7 @@ test_interface() {
 	download=$(echo "$result" | jq ".end.sum_received.bits_per_second / 1024")
 
 	printf "%s Kbps\n" "$download"
+	sleep 1
 }
 
 # -- Get the wan ip of the service
@@ -119,8 +120,11 @@ setup
 trap : HUP INT TERM
 
 config_load network
-# For each interface, run test_interface
-config_foreach test_interface interface
+if [ -n "$1" ]; then
+	test_interface "$1"
+else
+	config_foreach test_interface interface
+fi
 
 # Cleanup when the test is done
 cleanup


### PR DESCRIPTION
Dirty fix edge cases when iperf is not ready to accept new connections
with a sleep
Add option to the script in order to test a specifix interface