### PR TITLE
overthebox: Use the l3 device in otb-status

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.55
+PKG_VERSION:=0.56
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/bin/otb-status
+++ b/overthebox/files/bin/otb-status
@@ -34,7 +34,7 @@ fi
 
 WIDTH=73
 HEADERS="INTERFACE DEVICE STATUS PUBLIC_IP LATENCY"
-DATA='.device, $connectivity, $public_ip, $latency'
+DATA='if .l3_device then .l3_device else .device end, $connectivity, $public_ip, $latency'
 if [ "$FULL" = "1" ]; then
 	WIDTH=$((WIDTH + 18))
 	DATA="$DATA, .metric, .ip4table"


### PR DESCRIPTION
This fixes the 'otb-status' command while using LTE modems over ttyUSB
devices.