### PR TITLE
overthebox: Keep the dscp config file up to date

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.57
+PKG_VERSION:=0.58
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/etc/uci-defaults/1920-otb-qos
+++ b/overthebox/files/etc/uci-defaults/1920-otb-qos
@@ -4,6 +4,24 @@
 
 . /lib/functions.sh
 
+# If dscp config file hasn't change, ensure that it's up to date
+# 8103cf3ee36bc1855042709f062e1df7 : file from 7a6bf7db2f
+# 55411026b89bd3b2d81f32cb57d9a6ef : file from 8b1a8715d2
+# 7e091b8bf4383a43543fbf9e0fff418e : file from 0a57725b4c
+checksums="
+	8103cf3ee36bc1855042709f062e1df7
+	1319bd4ebb7ee3685eb3839bd9f5c51b
+	7e091b8bf4383a43543fbf9e0fff418e
+"
+
+for chksum in $checksums; do
+        if echo "$chksum  /etc/config/dscp" | md5sum -sc; then
+                echo "setting up new dscp config file"
+                otb-dscp-reset
+                exit 0
+        fi
+done
+
 _simplify_classes() {
 	class=
 	config_get class "$1" class "cs0"


### PR DESCRIPTION
If the user hasn't changed its dscp config file, copy the new
configuration