### PR TITLE
luci-app-overthebox: Don't check length of nil var

### DIFF
--- a/luci-app-overthebox/Makefile
+++ b/luci-app-overthebox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for the OverTheBox project
 LUCI_DEPENDS:=+bandwidth +luci-mod-admin-full +luci-app-firewall +luci-lib-nixio +luci-theme-ovh +otb-qos
 
-PKG_VERSION:=v1.19
+PKG_VERSION:=v1.20
 PKG_RELEASE:=1
 
 include ../luci/luci.mk

--- a/luci-app-overthebox/luasrc/controller/admin/overthebox.lua
+++ b/luci-app-overthebox/luasrc/controller/admin/overthebox.lua
@@ -508,7 +508,7 @@ function multipath_bandwidth()
     if dev ~= "lo" then
       local multipath = section["multipath"]
       bandwidth = luci.sys.exec("luci-bwc -i %q 2>/dev/null" % dev)
-      if string.len(bandwidth) == 0 then
+      if bandwidth == nil or string.len(bandwidth) == 0 then
         return
       end
       if multipath == "on" or multipath == "master" or multipath == "backup" or multipath == "handover" then


### PR DESCRIPTION
This code is checking bandwidth for all kind of interfaces ( including
lan_ifX interfaces that are not really interfaces )
Bump package while we're here