### PR TITLE
overthebox: Don't let jq print null when no error

### DIFF
--- a/overthebox/files/bin/otb-action-configure
+++ b/overthebox/files/bin/otb-action-configure
@@ -14,7 +14,7 @@ _get() {
 	otb_json_get "$config" "$1"
 }
 
-_get error >&2 && exit 1
+_get "error // empty" >&2 && exit 1
 
 # delete last conf
 


### PR DESCRIPTION
Signed-off-by: Adrien Gallouët <adrien@gallouet.fr>