### PR TITLE
overthebox: fix otb-check-config on initial config

### DIFF
--- a/overthebox/files/bin/otb-check-config
+++ b/overthebox/files/bin/otb-check-config
@@ -5,10 +5,7 @@
 . /lib/functions/network.sh
 . /lib/overthebox
 
-if [ "$(uci -q get "network.tun0")" != "interface" ]; then
-	otb-action-configure
-	exit
-fi
+[ "$(uci -q get "network.tun0")" = "interface" ] || otb-action-configure
 
 # Setup unknown devices
 for p in /sys/class/net/*; do


### PR DESCRIPTION
When the OTB first starts without config and the interfaces don't have
the proper routing rules, allow otb-check-config to do its work.

This fix is already applied in 150367acea1f.