### PR TITLE
overthebox: Add a 'first-setup' event

### DIFF
--- a/overthebox/files/etc/uci-defaults/1940-otb-event
+++ b/overthebox/files/etc/uci-defaults/1940-otb-event
@@ -1,0 +1,7 @@
+#!/bin/sh
+# shellcheck disable=SC1091
+# vim: set noexpandtab tabstop=4 shiftwidth=4 softtabstop=4 :
+
+. /lib/overthebox
+
+otb_save_event "first-setup"


### PR DESCRIPTION
This event will be trigger during the first boot, after a sysupgrade or
after a reset.