### PR TITLE
overthebox: Fix ifup/ifdown events name

### DIFF
--- a/overthebox/files/etc/hotplug.d/iface/90-overthebox
+++ b/overthebox/files/etc/hotplug.d/iface/90-overthebox
@@ -7,4 +7,4 @@
 details=$(jq -n -c --arg interface "$INTERFACE" --arg device "$DEVICE" \
 	'{ interface: $interface, device: $device }')
 
-otb_save_event "$ACTION-$INTERFACE" "$details"
+otb_save_event "$ACTION" "$details" "$ACTION-$INTERFACE"

--- a/overthebox/files/lib/overthebox
+++ b/overthebox/files/lib/overthebox
@@ -139,11 +139,13 @@ otb_get_data() {
 }
 
 otb_save_event() {
+	name=$1
 	details=$2
+	filename=${3:-$1}
 	[ "$details" ] || details="{}"
-	jq -n -c --arg name "$1" --arg timestamp "$(date +%s)" --argjson details "$details" \
+	jq -n -c --arg name "$name" --arg timestamp "$(date +%s)" --argjson details "$details" \
 		'{event_name: $name, timestamp: $timestamp|tonumber, details: $details}' \
-		| otb_todo "event-$1" otb_device_post events -d@-
+		| otb_todo "event-$filename" otb_device_post events -d@-
 }
 
 otb_led() {


### PR DESCRIPTION
Add an optional argument to otb_save_event to specify the name of the
todo, and by default, choose the name of the event