### PR TITLE
overthebox: Improve sysupgrade reliability

### DIFF
--- a/overthebox/files/bin/otb-action-sysupgrade
+++ b/overthebox/files/bin/otb-action-sysupgrade
@@ -24,8 +24,8 @@ fi
 cd /tmp
 
 otb_info "Downloading image from '$url'..."
-curl -sS --connect-timeout 5 "$url"     -o img.gz
 curl -sS --connect-timeout 5 "$url.sig" -o img.gz.sig
+curl -sS --connect-timeout 5 "$url"     -o img.gz
 
 usign -V -m img.gz -P /etc/opkg/keys
 


### PR DESCRIPTION
Sometimes the download of the image via tun0 (which is the default route
from the device) makes the latency explode and we're then unable to
download the signature, thus interrupting the sysupgrade.
We reverse the order of the downloads to make it less likely to get
connect timeout errors