### PR TITLE
overthebox: The use of dd is now useless

### DIFF
--- a/overthebox/files/bin/otb-check-config
+++ b/overthebox/files/bin/otb-check-config
@@ -105,7 +105,7 @@ done
 
 # Remove old paths
 
-glorytun path | dd obs=1M 2>/dev/null | while read -r _ _ _ IP _; do
+glorytun path 2>/dev/null | while read -r _ _ _ IP _; do
 	case "$OTB_PATH_LIST" in
 		*" $IP"*) ;;
 		*) glorytun path "$IP" down 2>/dev/null ;;


### PR DESCRIPTION
Fixed with https://github.com/angt/glorytun/commit/cce55fac2155997dbcad34ca2c9bc53d9e421ccd

Signed-off-by: Adrien Gallouët <adrien@gallouet.fr>