### PR TITLE
overthebox: Upgrade is now deprecated

### DIFF
--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.69
+PKG_VERSION:=0.70
 PKG_RELEASE:=0
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/bin/otb-action-upgrade
+++ b/overthebox/files/bin/otb-action-upgrade
@@ -2,39 +2,10 @@
 # shellcheck disable=SC1091
 # vim: set noexpandtab tabstop=4 shiftwidth=4 softtabstop=4 :
 
-set -e
-set -o pipefail
+. /lib/overthebox
 
-if [ -n "$1" ]; then
-	. /lib/overthebox
+msg="Upgrading is deprecated... Please consider a sysupgrade."
+echo "$msg"
+otb_err "$msg"
 
-	# always rewrite distfeeds.conf if the channel is not develop
-	channel=$(otb_json_get "$1" "arguments.release_channel")
-	[ "$channel" = "develop" ] || otb-action-updateReleaseChannel
-fi
-
-opkg update
-
-PKGS=$(opkg list-upgradable -V0 | cut -d' ' -f1)
-
-if [ -z "$PKGS" ]; then
-	echo "Nothing to update."
-	exit 0
-fi
-
-if ! opkg info base-files | awk '/Version/{a[$0]++}END{exit length(a)!=1}'; then
-	echo "Upgrading is not possible... Please consider a sysupgrade."
-	exit 1
-fi
-
-UPGRADE_DIR="/tmp/otb-upgrade"
-
-rm -rf $UPGRADE_DIR
-mkdir -p $UPGRADE_DIR
-cd $UPGRADE_DIR
-
-for PKG in $PKGS; do
-	opkg upgrade --download-only "$PKG"
-done
-
-opkg install --force-overwrite ./*.ipk
+exit 0


### PR DESCRIPTION
To upgrade an OverTheBox device, a sysupgrade is now needed