### PR TITLE
Release v0.6.35 in beta channel

### DIFF
--- a/luci-app-overthebox/Makefile
+++ b/luci-app-overthebox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for the OverTheBox project
 LUCI_DEPENDS:=+bandwidth +luci-mod-admin-full +luci-app-firewall +luci-lib-nixio +luci-theme-ovh +otb-qos
 
-PKG_VERSION:=v1.21
+PKG_VERSION:=v1.21.1
 PKG_RELEASE:=1
 
 include ../luci/luci.mk

--- a/luci-app-overthebox/luasrc/controller/admin/overthebox.lua
+++ b/luci-app-overthebox/luasrc/controller/admin/overthebox.lua
@@ -163,7 +163,8 @@ function interfaces_status()
   if f then
     local content = f:read("*all")
     f:close()
-    local ip = string.match(content, "X%-Otb%-Client%-Ip: (%d+%.%d+%.%d+%.%d+)", 0)
+    content = string.lower(content)
+    local ip = string.match(content, "x%-otb%-client%-ip: (%d+%.%d+%.%d+%.%d+)", 0)
     if ip then
       mArray.overthebox["wan_addr"] = ip
     end

--- a/otb-graph/Makefile
+++ b/otb-graph/Makefile
@@ -1,0 +1,36 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=otb-graph
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+SECTION:=base
+CATEGORY:=Base system
+DEPENDS:=+curl +overthebox
+TITLE:=Provisioning Graph
+endef
+
+define Package/$(PKG_NAME)/description
+Graph daemon
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/conffiles
+/etc/config/$(PKG_NAME)
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) bin $(1)/bin/$(PKG_NAME)
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) init $(1)/etc/init.d/$(PKG_NAME)
+	$(INSTALL_DIR) $(1)/etc/config
+	touch $(1)/etc/config/$(PKG_NAME)
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/otb-graph/bin
+++ b/otb-graph/bin
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+set -e
+. /lib/overthebox
+
+HOST=${1:-none}
+FREQ=${2:-60}
+PERIOD=
+
+_add() {
+    printf "${PERIOD}"'{"name":"%s","value":%s,"tags":{"host":"'"$HOST"'"%s}}' "$@"
+    PERIOD=,
+}
+
+_graph() {
+    PERIOD=
+
+    printf '['
+
+    while read -r IFACE RX _ _ _ _ _ _ _ TX _ ; do
+        case "${IFACE}" in
+        *:)
+            LOCAL_NAME=$(/sbin/uci -q show "network" | grep "'${IFACE%:}'" | cut -d. -f2)
+            # Send latency of intefaces
+            LATENCY_FILE_NAME=/tmp/otb-data/$LOCAL_NAME/latency
+            if [ -f "$LATENCY_FILE_NAME" ]
+            then
+                LATENCY=$(cat "$LATENCY_FILE_NAME")
+                if [ -n "$LATENCY" ]
+                then
+                    _add "icmp_latency" "$LATENCY" ',"iface":"'"${IFACE%:}"'","uci_name":"'"$LOCAL_NAME"'"'
+                fi
+            fi
+
+            # Adding the rate counter
+            LOCAL_NAME=${LOCAL_NAME:-none}
+            _add "linux_net_bytes" "${RX}" ',"direction":"in","iface":"'"${IFACE%:}"'","uci_name":"'"$LOCAL_NAME"'"'
+            _add "linux_net_bytes" "${TX}" ',"direction":"out","iface":"'"${IFACE%:}"'","uci_name":"'"$LOCAL_NAME"'"'
+            ;;
+        esac
+    done < /proc/net/dev
+
+    read -r AVG1 _ _ < /proc/loadavg
+    _add "proc_loadavg_1m" "${AVG1}"
+
+    while read -r NAME VALUE _ ; do
+        case "${NAME}" in
+        MemFree:)
+            _add "os_mem_free" "${VALUE}"
+            ;;
+        esac
+    done < /proc/meminfo
+
+    printf ']'
+}
+while true; do
+        otb_reload
+        graph_data=$(_graph)
+        otb_service_post "metrics" --data "$graph_data"
+        sleep "$FREQ"
+done
+

--- a/otb-graph/init
+++ b/otb-graph/init
@@ -1,0 +1,40 @@
+#!/bin/sh /etc/rc.common
+# shellcheck disable=SC2039
+# vim: set noexpandtab tabstop=4 shiftwidth=4 softtabstop=4 :
+
+# shellcheck disable=SC2034
+{
+	START=90
+	STOP=10
+	USE_PROCD=1
+}
+
+validate_section() {
+	uci_validate_section graph provisioning "$1" \
+		'enable:bool:1'            \
+		'freq:uinteger'
+}
+
+start_instance() {
+	local enable freq
+	validate_section "$1" || return
+
+	[ "$enable" = "0" ] && return
+
+	hostname=$(uci -q get system.@system[0].hostname)
+
+	procd_open_instance
+	procd_set_param command /bin/otb-graph "$hostname" "$freq"
+	procd_set_param respawn 0 5 0
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+start_service() {
+	config_load graph
+	config_foreach start_instance provisioning
+}
+
+service_triggers() {
+	procd_add_reload_trigger graph
+}

--- a/otb/Makefile
+++ b/otb/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=otb
 PKG_VERSION:=0.6
-PKG_RELEASE:=33
+PKG_RELEASE:=35
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.70.2
+PKG_VERSION:=0.70.3
 PKG_RELEASE:=0
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.70.4
+PKG_VERSION:=0.70.5
 PKG_RELEASE:=0
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.70
+PKG_VERSION:=0.70.1
 PKG_RELEASE:=0
 
 include $(INCLUDE_DIR)/package.mk
@@ -9,6 +9,7 @@ include $(INCLUDE_DIR)/package.mk
 MY_DEPENDS := \
     graph glorytun glorytun-udp mptcp shadowsocks-libev  \
     kmod-macvlan jq curl ca-bundle ca-certificates \
+    otb-graph \
     @LIBCURL_THREADED_RESOLVER
 
 define Package/$(PKG_NAME)

--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.70.3
+PKG_VERSION:=0.70.4
 PKG_RELEASE:=0
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/Makefile
+++ b/overthebox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overthebox
-PKG_VERSION:=0.70.1
+PKG_VERSION:=0.70.2
 PKG_RELEASE:=0
 
 include $(INCLUDE_DIR)/package.mk

--- a/overthebox/files/bin/otb-action-autoqos
+++ b/overthebox/files/bin/otb-action-autoqos
@@ -1,0 +1,80 @@
+#!/bin/sh
+# shellcheck disable=SC1091,SC2039
+
+. /lib/overthebox
+
+export test_time=5       # Do the iperf during 5 seconds
+export skip_test_time=1  # Skip the data of the first second of the test
+default_percentage=80
+
+server_ip="$(uci -q get glorytun.tun0.server)" || {
+	otb_err "Couldn't find server ip"
+	exit 1
+}
+export server_ip
+
+. /lib/functions.sh
+. /lib/functions/network.sh
+
+trap : HUP INT TERM
+
+autoqos() {
+	iface="$1"
+	percent="${2:-$default_percentage}"
+
+	result="$(speedtest "$1")"
+
+	upload="$(echo "$result" | awk '{print $1}')"
+	download="$(echo "$result" | awk '{print $2}')"
+
+	if [ -z "$upload" ] || [ "$upload" = "0" ]; then
+		otb_err "Upload is 0"
+		return
+	fi
+
+	if [ -z "$download" ] || [ "$download" = "0" ]; then
+		otb_err "Download is 0"
+		return
+	fi
+
+	upload=$((upload * percent / 100))
+	download=$((download * percent / 100))
+
+	otb_info "Traffic control for $iface download set to: $download kbit/s"
+	otb_info "Traffic control for $iface upload set to: $upload kbit/s"
+
+	uci -q batch <<-EOF
+	set network.$iface.trafficcontrol='static'
+	set network.$iface.download='$download'
+	set network.$iface.upload='$upload'
+	commit
+	EOF
+}
+
+setup() {
+	otb_call_api POST ipt/iperf >/dev/null || return
+	/etc/init.d/otb-qos stop 2>/dev/null   || true
+}
+
+cleanup() {
+	otb_call_api DELETE ipt/iperf >/dev/null
+	/etc/init.d/otb-qos start
+}
+
+if setup; then
+	iface=$(otb_json_get "$1" iface 2>/dev/null)
+	percent=$(otb_json_get "$1" percent 2>/dev/null)
+	if [ "$(uci -q get "network.$iface")" = interface ]; then
+		autoqos "$iface" "$percent"
+	else
+        for interface in $(uci -q get firewall.wan.network); do
+            if [ "$(uci -q get "network.$interface")" = interface ]; then
+                autoqos "$interface"
+            fi
+        done
+	fi
+	cleanup
+else
+	otb_err "Couldn't start iperf3"
+	exit 1
+fi

--- a/overthebox/files/bin/otb-action-configure
+++ b/overthebox/files/bin/otb-action-configure
@@ -29,7 +29,7 @@ fi
 
 # delete last conf
 
-for conf in glorytun shadowsocks graph; do
+for conf in glorytun shadowsocks graph otb-graph; do
 	true > /etc/config/"$conf"
 	uci -q revert "$conf"
 done
@@ -144,6 +144,9 @@ set system.@system[0].log_prefix=$(_get log_conf.key)
 set graph.opentsdb=opentsdb
 set graph.opentsdb.url=$(_get graph_conf.host)
 set graph.opentsdb.freq=$(_get graph_conf.write_frequency)
+
+set graph.provisioning=provisioning
+set graph.provisioning.freq=$(_get graph_conf.write_frequency)
 
 commit
 EOF

--- a/overthebox/files/bin/otb-action-speedtest
+++ b/overthebox/files/bin/otb-action-speedtest
@@ -27,47 +27,17 @@ cleanup() {
 	/etc/init.d/otb-qos start
 }
 
-speedtest() {
-	local ipaddr gateway
-
-	network_get_ipaddr ipaddr "$1"
-	[ "$ipaddr" ] || return
-
-	network_get_gateway gateway "$1"
-	[ "$gateway" ] || return
-
-	do_iperf() {
-		iperf3 --client "$server_ip" --port 5008 \
-		       --time "$test_time" --omit "$skip_test_time" \
-		       --bind "$ipaddr" --json "$@" \
-			   | jq "(.end.sum_received.bits_per_second // 0) / 1000 | floor"
-	}
-
-	# loop five times max to handle speedtest timeout when determining upload speed
-	for i in $(seq 1 1 5); do
-		upload="$(do_iperf)" || return
-		if [ "$upload" -ne 0 ]; then
-			break
-		fi
-	done
-
-	# loop five times max to handle speedtest timeout when determining download speed
-	for i in $(seq 1 1 5); do
-		download="$(do_iperf -R)" || return
-		if [ "$download" -ne 0 ]; then
-			break
-		fi
-	done
-
-	printf "[%8s]  Upload: %8s kbits/s  Download: %8s kbit/s\\n" "$1" "$upload" "$download"
+_speedtest() {
+	speedtest "$1" | awk -v iface="$1" \
+	'{ printf "[%8s]  Upload:  %8d kbits/s  Download: %8d kbit/s\n", iface, $1, $2 }'
 }
 
 if setup; then
 	if [ "$(uci -q get "network.$1")" = interface ]; then
-		speedtest "$1"
+		_speedtest "$1"
 	else
 		config_load network
-		config_foreach speedtest interface
+		config_foreach _speedtest interface
 	fi
 	cleanup
 else

--- a/overthebox/files/bin/otb-action-sysupgrade
+++ b/overthebox/files/bin/otb-action-sysupgrade
@@ -15,7 +15,12 @@ export_bootdevice || {
 otb_save_action_id "$1" 2>/dev/null || true
 
 if [ -z "$1" ]; then
-	url="$(grep core /etc/opkg/distfeeds.conf | cut -d' ' -f3)/../latest.img.gz"
+	# Get image URL from provisionning
+	prov_url="$(otb_device_get release_channel | jq -r '.image_url')"
+	case "$prov_url" in
+		http*.img.gz|ftp*.img.gz) url=$prov_url ;;
+		*) otb_err "No valid image URL found !" ; exit 1 ;;
+	esac 
 else
 	case "$1" in
 		http*.img.gz|ftp*.img.gz) url=$1 ;;

--- a/overthebox/files/bin/otb-daemon
+++ b/overthebox/files/bin/otb-daemon
@@ -37,7 +37,10 @@ _run() {
 		[ -f "$file" ] && (. "$file") && rm -f "$file"
 	done
 
-	ret=$(otb_device_get actions/todo --dump-header "$OTB_HEADERS_FILE") || (sleep 30 && return)
+	ret=$(otb_device_get actions/todo --dump-header "$OTB_HEADERS_FILE") || {
+		sleep 30
+		return
+	}
 
 	if [ -z "$OTB_SERVICE_ID" ] || [ "$(echo "$ret" | jq -r '.class' 2>/dev/null)" = "Client::Unauthorized" ]; then
 		read -r LINE < "$OTB_HEADERS_FILE"

--- a/overthebox/files/lib/overthebox
+++ b/overthebox/files/lib/overthebox
@@ -156,6 +156,41 @@ otb_save_action_id() {
 	EOF
 }
 
+speedtest() {
+	local ipaddr gateway
+
+	network_get_ipaddr ipaddr "$1"
+	[ "$ipaddr" ] || return
+
+	network_get_gateway gateway "$1"
+	[ "$gateway" ] || return
+
+	do_iperf() {
+		iperf3 --client "$server_ip" --port 5008 \
+		       --time "$test_time" --omit "$skip_test_time" \
+		       --bind "$ipaddr" --json "$@" \
+			   | jq "(.end.sum_received.bits_per_second // 0) / 1000 | floor"
+	}
+
+	# loop five times max to handle speedtest timeout when determining upload speed
+	for i in $(seq 1 1 5); do
+		upload="$(do_iperf)" || return
+		if [ "$upload" -ne 0 ]; then
+			break
+		fi
+	done
+
+	# loop five times max to handle speedtest timeout when determining download speed
+	for i in $(seq 1 1 5); do
+		download="$(do_iperf -R)" || return
+		if [ "$download" -ne 0 ]; then
+			break
+		fi
+	done
+
+	printf "%8s %8s" "$upload" "$download"
+}
+
 otb_led() {
 	sysfs=$(uci -q get "system.$1_led.sysfs")
 	[ "$sysfs" ] || return 0


### PR DESCRIPTION
Features:
* Add package otb-graph, this is plan to be a replacement for graph package. This is used to retrieve necessary information to realize bandwidth and system usage graphics on customer panel.
* Add action otb-action-qos, which allow to determine automatically a correct "traffic control" value on each WAN interfaces.
* Add package Nano by default in image.
* Add optional packages :  prometheus-node-exporter-lua-*. Those packages are not installed by default, but can be installed using opkg.
* Update official packages from openwrt 18.06.
* Upgrade system version to v3.11.0.

Bugs : 
* Resolve an issue with jq parser, which was generating a large amount of logs if wan interfaces where unreachable.
* Resolve a bug on LUCI web interface, which was showing 0.0.0.0 instead of OverTheBox service public IP.
* Resolve a bug with action  otb-action-sysupgrade which was not retrieving the correct URL to download an image if an URL was not provide as an argument.

Misc : 
 * Move functional code of otb-action-speedtest to lib/overthebox. This change has no impact on the behavior of action otb-action-speedtest.
 * Use git module to build an image